### PR TITLE
Fix Stripe customer and payment URLs

### DIFF
--- a/lib/data/models/company_model.dart
+++ b/lib/data/models/company_model.dart
@@ -643,7 +643,7 @@ abstract class GatewayEntity extends Object
   static String getClientUrl({String gatewayId, String customerReference}) {
     switch (gatewayId) {
       case kGatewayStripe:
-        return 'https://dashboard.stripe.com/customers/$customerReference}';
+        return 'https://dashboard.stripe.com/customers/$customerReference';
       default:
         return null;
     }
@@ -652,7 +652,7 @@ abstract class GatewayEntity extends Object
   static String getPaymentUrl({String gatewayId, String transactionReference}) {
     switch (gatewayId) {
       case kGatewayStripe:
-        return 'https://dashboard.stripe.com/payments/$transactionReference}';
+        return 'https://dashboard.stripe.com/payments/$transactionReference';
       default:
         return null;
     }


### PR DESCRIPTION
Stripe dashboard customer and payment URLs are currently broken, due to an extra trailing `}`. This PR fixes that :)