### PR TITLE
fix fallback locale

### DIFF
--- a/lib/utils/i18n.dart
+++ b/lib/utils/i18n.dart
@@ -62386,7 +62386,7 @@ mixin LocalizationsProvider on LocaleCodeAware {
         _localizedValues[localeCode][lookupKey.replaceFirst('_id', '')] ??
         key;
 
-    if (value.isEmpty) {
+    if (value.isEmpty || value == key) {
       print('ERROR: localization key not found - $key');
 
       final englishValue = _localizedValues['en'][lookupKey] ?? '';


### PR DESCRIPTION
If the value didn't exist for the localeCode then the fallback option did not work because value would be equal to key and would not be empty.