### PR TITLE
fix isSelected in menu_drawer

### DIFF
--- a/lib/ui/app/menu_drawer.dart
+++ b/lib/ui/app/menu_drawer.dart
@@ -538,10 +538,9 @@ class _DrawerTileState extends State<DrawerTile> {
       route = widget.entityType.name;
     }
 
-    final isSelected =
-        uiState.currentRoute.startsWith('/${toSnakeCase(route)}') &&
-            (state.uiState.filterEntityType == null ||
-                !state.prefState.isFilterVisible);
+    final isSelected = (uiState.currentRoute == '/${toSnakeCase(route)}') &&
+        (state.uiState.filterEntityType == null ||
+            !state.prefState.isFilterVisible);
 
     final prefState = state.prefState;
     final inactiveColor = prefState


### PR DESCRIPTION
     fix isSelected in menu_drawer when more than 1 route has the same start name
     EX. we have 2 routes [room, room_types]
     when room_types selected, room also selected 🤔