### PR TITLE
Feature/offline banner fix

### DIFF
--- a/lib/utils/connection_status.dart
+++ b/lib/utils/connection_status.dart
@@ -10,7 +10,7 @@ class ConnectionStatusSingleton {
 
   static ConnectionStatusSingleton getInstance() => _singleton;
 
-  bool hasConnection = false;
+  bool hasConnection = true;
 
   StreamController connectionChangeController =
       new StreamController.broadcast();


### PR DESCRIPTION
I think the reason for seeing the "No connection" message even though they're online is because the default state assumed by the app is "no connection" until proven otherwise, and once a http request succeeds, it is set to true. This results in a delay between starting the app, seeing an offline banner, and then having the banner removed once a connection goes through over the network.

This commit reverses the logic, assumes the user is connected until proven otherwise, not showing the banner until a connection has failed.