### PR TITLE
feat: Miettage-Multiplikator für Invoice-Zeilenpositionen

### DIFF
--- a/lib/data/models/invoice_model.dart
+++ b/lib/data/models/invoice_model.dart
@@ -1636,6 +1636,7 @@ abstract class InvoiceItemEntity
       notes: '',
       cost: 0,
       productCost: 0,
+      rentalDays: 1,
       quantity:
           (company.defaultQuantity || !company.enableProductQuantity) ? 1 : 0,
       taxName1: '',
@@ -1676,6 +1677,9 @@ abstract class InvoiceItemEntity
 
   @BuiltValueField(wireName: 'product_cost')
   double get productCost;
+
+  @BuiltValueField(wireName: 'rental_days')
+  double get rentalDays;
 
   double get quantity;
 
@@ -1729,7 +1733,8 @@ abstract class InvoiceItemEntity
       total(invoice, precision) - taxAmount(invoice, precision);
 
   double total(InvoiceEntity invoice, int precision) {
-    var total = quantity * cost;
+    final days = rentalDays > 0 ? rentalDays : 1;
+    var total = quantity * cost * days;
 
     if (discount != 0) {
       if (invoice.isAmountDiscount) {
@@ -1858,6 +1863,7 @@ abstract class InvoiceItemEntity
   // ignore: unused_element
   static void _initializeBuilder(InvoiceItemEntityBuilder builder) => builder
     ..productCost = 0
+    ..rentalDays = 1
     ..taxCategoryId = '';
 
   static Serializer<InvoiceItemEntity> get serializer =>

--- a/lib/data/models/invoice_model.dart
+++ b/lib/data/models/invoice_model.dart
@@ -1848,6 +1848,13 @@ abstract class InvoiceItemEntity
     return item;
   }
 
+  double get margin => cost > 0 ? (cost - productCost) / cost * 100 : 0;
+
+  static double calcEK(double vk, double margin) => vk * (1 - margin / 100);
+
+  static double calcVK(double ek, double margin) =>
+      margin < 100 ? ek / (1 - margin / 100) : 0;
+
   // ignore: unused_element
   static void _initializeBuilder(InvoiceItemEntityBuilder builder) => builder
     ..productCost = 0

--- a/lib/data/models/invoice_model.g.dart
+++ b/lib/data/models/invoice_model.g.dart
@@ -784,6 +784,9 @@ class _$InvoiceItemEntitySerializer
       'product_cost',
       serializers.serialize(object.productCost,
           specifiedType: const FullType(double)),
+      'rental_days',
+      serializers.serialize(object.rentalDays,
+          specifiedType: const FullType(double)),
       'quantity',
       serializers.serialize(object.quantity,
           specifiedType: const FullType(double)),
@@ -881,6 +884,10 @@ class _$InvoiceItemEntitySerializer
           break;
         case 'product_cost':
           result.productCost = serializers.deserialize(value,
+              specifiedType: const FullType(double))! as double;
+          break;
+        case 'rental_days':
+          result.rentalDays = serializers.deserialize(value,
               specifiedType: const FullType(double))! as double;
           break;
         case 'quantity':
@@ -2569,6 +2576,8 @@ class _$InvoiceItemEntity extends InvoiceItemEntity {
   @override
   final double productCost;
   @override
+  final double rentalDays;
+  @override
   final double quantity;
   @override
   final String taxName1;
@@ -2612,6 +2621,7 @@ class _$InvoiceItemEntity extends InvoiceItemEntity {
       required this.notes,
       required this.cost,
       required this.productCost,
+      required this.rentalDays,
       required this.quantity,
       required this.taxName1,
       required this.taxRate1,
@@ -2646,6 +2656,7 @@ class _$InvoiceItemEntity extends InvoiceItemEntity {
         notes == other.notes &&
         cost == other.cost &&
         productCost == other.productCost &&
+        rentalDays == other.rentalDays &&
         quantity == other.quantity &&
         taxName1 == other.taxName1 &&
         taxRate1 == other.taxRate1 &&
@@ -2674,6 +2685,7 @@ class _$InvoiceItemEntity extends InvoiceItemEntity {
     _$hash = $jc(_$hash, notes.hashCode);
     _$hash = $jc(_$hash, cost.hashCode);
     _$hash = $jc(_$hash, productCost.hashCode);
+    _$hash = $jc(_$hash, rentalDays.hashCode);
     _$hash = $jc(_$hash, quantity.hashCode);
     _$hash = $jc(_$hash, taxName1.hashCode);
     _$hash = $jc(_$hash, taxRate1.hashCode);
@@ -2702,6 +2714,7 @@ class _$InvoiceItemEntity extends InvoiceItemEntity {
           ..add('notes', notes)
           ..add('cost', cost)
           ..add('productCost', productCost)
+          ..add('rentalDays', rentalDays)
           ..add('quantity', quantity)
           ..add('taxName1', taxName1)
           ..add('taxRate1', taxRate1)
@@ -2742,6 +2755,10 @@ class InvoiceItemEntityBuilder
   double? _productCost;
   double? get productCost => _$this._productCost;
   set productCost(double? productCost) => _$this._productCost = productCost;
+
+  double? _rentalDays;
+  double? get rentalDays => _$this._rentalDays;
+  set rentalDays(double? rentalDays) => _$this._rentalDays = rentalDays;
 
   double? _quantity;
   double? get quantity => _$this._quantity;
@@ -2823,6 +2840,7 @@ class InvoiceItemEntityBuilder
       _notes = $v.notes;
       _cost = $v.cost;
       _productCost = $v.productCost;
+      _rentalDays = $v.rentalDays;
       _quantity = $v.quantity;
       _taxName1 = $v.taxName1;
       _taxRate1 = $v.taxRate1;
@@ -2869,6 +2887,8 @@ class InvoiceItemEntityBuilder
               cost, r'InvoiceItemEntity', 'cost'),
           productCost: BuiltValueNullFieldError.checkNotNull(
               productCost, r'InvoiceItemEntity', 'productCost'),
+          rentalDays: BuiltValueNullFieldError.checkNotNull(
+              rentalDays, r'InvoiceItemEntity', 'rentalDays'),
           quantity: BuiltValueNullFieldError.checkNotNull(
               quantity, r'InvoiceItemEntity', 'quantity'),
           taxName1: BuiltValueNullFieldError.checkNotNull(

--- a/lib/ui/invoice/edit/invoice_edit_desktop.dart
+++ b/lib/ui/invoice/edit/invoice_edit_desktop.dart
@@ -1079,7 +1079,8 @@ class InvoiceEditDesktopState extends State<InvoiceEditDesktop>
                                       .toList();
                                   final hasProductCost = productItems
                                       .any((item) => item.productCost > 0);
-                                  if (!hasProductCost) return SizedBox();
+                                  if (!hasProductCost)
+                                    return SizedBox();
                                   final precision =
                                       precisionForInvoice(state, invoice);
                                   final totalEK = productItems.fold(

--- a/lib/ui/invoice/edit/invoice_edit_desktop.dart
+++ b/lib/ui/invoice/edit/invoice_edit_desktop.dart
@@ -1071,6 +1071,62 @@ class InvoiceEditDesktopState extends State<InvoiceEditDesktop>
                                         : null,
                                   ),
                                 ),
+                                Builder(builder: (context) {
+                                  final productItems = invoice.lineItems
+                                      .where((item) =>
+                                          item.typeId !=
+                                          InvoiceItemEntity.TYPE_TASK)
+                                      .toList();
+                                  final hasProductCost = productItems
+                                      .any((item) => item.productCost > 0);
+                                  if (!hasProductCost) return SizedBox();
+                                  final precision =
+                                      precisionForInvoice(state, invoice);
+                                  final totalEK = productItems.fold(
+                                      0.0,
+                                      (sum, item) =>
+                                          sum + item.productCost * item.quantity);
+                                  final totalVK = invoice.calculateSubtotal(
+                                      precision: precision);
+                                  final totalMarginAbs = totalVK - totalEK;
+                                  final totalMarginPct = totalVK > 0
+                                      ? totalMarginAbs / totalVK * 100
+                                      : 0.0;
+                                  return Column(children: [
+                                    TextFormField(
+                                      enabled: false,
+                                      style:
+                                          TextStyle(color: state.greyColor),
+                                      decoration: InputDecoration(
+                                          labelText: 'EK gesamt'),
+                                      textAlign: TextAlign.end,
+                                      key: ValueKey(
+                                          '__invoice_total_ek_${totalEK}_${invoice.clientId}__'),
+                                      initialValue: formatNumber(
+                                        totalEK,
+                                        context,
+                                        clientId: invoice.isPurchaseOrder
+                                            ? null
+                                            : invoice.clientId,
+                                        vendorId: invoice.isPurchaseOrder
+                                            ? invoice.vendorId
+                                            : null,
+                                      ),
+                                    ),
+                                    TextFormField(
+                                      enabled: false,
+                                      style:
+                                          TextStyle(color: state.greyColor),
+                                      decoration: InputDecoration(
+                                          labelText: 'Marge gesamt'),
+                                      textAlign: TextAlign.end,
+                                      key: ValueKey(
+                                          '__invoice_total_margin_${totalMarginAbs}_${invoice.clientId}__'),
+                                      initialValue:
+                                          '${formatNumber(totalMarginAbs, context, clientId: invoice.isPurchaseOrder ? null : invoice.clientId, vendorId: invoice.isPurchaseOrder ? invoice.vendorId : null)} (${totalMarginPct.toStringAsFixed(1)} %)',
+                                    ),
+                                  ]);
+                                }),
                                 if (invoice.isOld &&
                                     (invoice.isInvoice || invoice.isQuote))
                                   TextFormField(

--- a/lib/ui/invoice/edit/invoice_edit_items.dart
+++ b/lib/ui/invoice/edit/invoice_edit_items.dart
@@ -110,8 +110,11 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
   final _productKeyController = TextEditingController();
   final _notesController = TextEditingController();
   final _costController = TextEditingController();
+  final _productCostController = TextEditingController();
+  final _marginController = TextEditingController();
   final _qtyController = TextEditingController();
   final _discountController = TextEditingController();
+  bool _isUpdatingFromCalculation = false;
   final _custom1Controller = TextEditingController();
   final _custom2Controller = TextEditingController();
   final _custom3Controller = TextEditingController();
@@ -136,6 +139,10 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
     _notesController.text = invoiceItem.notes;
     _costController.text = formatNumber(invoiceItem.cost, context,
         formatNumberType: FormatNumberType.inputMoney)!;
+    _productCostController.text = formatNumber(invoiceItem.productCost, context,
+        formatNumberType: FormatNumberType.inputMoney)!;
+    _marginController.text = formatNumber(invoiceItem.margin, context,
+        formatNumberType: FormatNumberType.inputAmount)!;
     _qtyController.text = formatNumber(invoiceItem.quantity, context,
         formatNumberType: FormatNumberType.inputAmount)!;
     _discountController.text = formatNumber(invoiceItem.discount, context,
@@ -149,6 +156,7 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
       _productKeyController,
       _notesController,
       _costController,
+      _productCostController,
       _qtyController,
       _discountController,
       _custom1Controller,
@@ -177,14 +185,28 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
       controller.removeListener(_onTextChanged);
       controller.dispose();
     });
+    _marginController.dispose();
 
     super.dispose();
   }
 
   void _onTextChanged() {
+    _updateMarginDisplay();
     _debouncer.run(() {
       _onChanged();
     });
+  }
+
+  void _updateMarginDisplay() {
+    if (_isUpdatingFromCalculation) return;
+    final vk = parseDouble(_costController.text) ?? 0;
+    final ek = parseDouble(_productCostController.text) ?? 0;
+    final margin = vk > 0 ? (vk - ek) / vk * 100 : 0.0;
+    final formatted = formatNumber(margin, context,
+        formatNumberType: FormatNumberType.inputAmount)!;
+    if (_marginController.text != formatted) {
+      _marginController.text = formatted;
+    }
   }
 
   void _onChanged() {
@@ -194,6 +216,7 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
       ..productKey = _productKeyController.text.trim()
       ..notes = _notesController.text
       ..cost = parseDouble(_costController.text)
+      ..productCost = parseDouble(_productCostController.text)
       ..quantity = parseDouble(_qtyController.text)
       ..discount = parseDouble(_discountController.text)
       ..customValue1 = _custom1Controller.text.trim()
@@ -307,6 +330,34 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
                   TextInputType.numberWithOptions(decimal: true, signed: true),
               onSavePressed: widget.entityViewModel.onSavePressed,
             ),
+            if (!widget.invoiceItem.isTask) ...[
+              DecoratedFormField(
+                label: 'EK',
+                controller: _productCostController,
+                keyboardType:
+                    TextInputType.numberWithOptions(decimal: true, signed: true),
+                onSavePressed: widget.entityViewModel.onSavePressed,
+              ),
+              DecoratedFormField(
+                label: 'Marge %',
+                controller: _marginController,
+                keyboardType:
+                    TextInputType.numberWithOptions(decimal: true, signed: true),
+                onSavePressed: widget.entityViewModel.onSavePressed,
+                onChanged: (value) {
+                  if (_isUpdatingFromCalculation) return;
+                  _isUpdatingFromCalculation = true;
+                  final vk = parseDouble(_costController.text) ?? 0;
+                  final margin = parseDouble(value) ?? 0;
+                  final ek = InvoiceItemEntity.calcEK(vk, margin);
+                  final formatted = formatNumber(ek, context,
+                      formatNumberType: FormatNumberType.inputMoney)!;
+                  _productCostController.text = formatted;
+                  _isUpdatingFromCalculation = false;
+                  _debouncer.run(() => _onChanged());
+                },
+              ),
+            ],
             company.enableProductQuantity
                 ? DecoratedFormField(
                     label: widget.invoiceItem.isTask

--- a/lib/ui/invoice/edit/invoice_edit_items.dart
+++ b/lib/ui/invoice/edit/invoice_edit_items.dart
@@ -198,7 +198,8 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
   }
 
   void _updateMarginDisplay() {
-    if (_isUpdatingFromCalculation) return;
+    if (_isUpdatingFromCalculation)
+      return;
     final vk = parseDouble(_costController.text) ?? 0;
     final ek = parseDouble(_productCostController.text) ?? 0;
     final margin = vk > 0 ? (vk - ek) / vk * 100 : 0.0;
@@ -345,7 +346,8 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
                     TextInputType.numberWithOptions(decimal: true, signed: true),
                 onSavePressed: widget.entityViewModel.onSavePressed,
                 onChanged: (value) {
-                  if (_isUpdatingFromCalculation) return;
+                  if (_isUpdatingFromCalculation)
+                    return;
                   _isUpdatingFromCalculation = true;
                   final vk = parseDouble(_costController.text) ?? 0;
                   final margin = parseDouble(value) ?? 0;

--- a/lib/ui/invoice/edit/invoice_edit_items.dart
+++ b/lib/ui/invoice/edit/invoice_edit_items.dart
@@ -112,6 +112,7 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
   final _costController = TextEditingController();
   final _productCostController = TextEditingController();
   final _marginController = TextEditingController();
+  final _rentalDaysController = TextEditingController();
   final _qtyController = TextEditingController();
   final _discountController = TextEditingController();
   bool _isUpdatingFromCalculation = false;
@@ -143,6 +144,8 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
         formatNumberType: FormatNumberType.inputMoney)!;
     _marginController.text = formatNumber(invoiceItem.margin, context,
         formatNumberType: FormatNumberType.inputAmount)!;
+    _rentalDaysController.text = formatNumber(invoiceItem.rentalDays, context,
+        formatNumberType: FormatNumberType.inputAmount) ?? '';
     _qtyController.text = formatNumber(invoiceItem.quantity, context,
         formatNumberType: FormatNumberType.inputAmount)!;
     _discountController.text = formatNumber(invoiceItem.discount, context,
@@ -186,6 +189,7 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
       controller.dispose();
     });
     _marginController.dispose();
+    _rentalDaysController.dispose();
 
     super.dispose();
   }
@@ -218,6 +222,7 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
       ..notes = _notesController.text
       ..cost = parseDouble(_costController.text)
       ..productCost = parseDouble(_productCostController.text)
+      ..rentalDays = parseDouble(_rentalDaysController.text) ?? 1
       ..quantity = parseDouble(_qtyController.text)
       ..discount = parseDouble(_discountController.text)
       ..customValue1 = _custom1Controller.text.trim()
@@ -331,6 +336,14 @@ class ItemEditDetailsState extends State<ItemEditDetails> {
                   TextInputType.numberWithOptions(decimal: true, signed: true),
               onSavePressed: widget.entityViewModel.onSavePressed,
             ),
+            if (!widget.invoiceItem.isTask)
+              DecoratedFormField(
+                label: 'Miettage',
+                controller: _rentalDaysController,
+                keyboardType:
+                    TextInputType.numberWithOptions(decimal: true),
+                onSavePressed: widget.entityViewModel.onSavePressed,
+              ),
             if (!widget.invoiceItem.isTask) ...[
               DecoratedFormField(
                 label: 'EK',

--- a/lib/ui/invoice/edit/invoice_edit_items_desktop.dart
+++ b/lib/ui/invoice/edit/invoice_edit_items_desktop.dart
@@ -60,6 +60,8 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
   static const COLUMN_TAX3 = 'tax3';
   static const COLUMN_TAX_CATEGORY = 'tax_category';
   static const COLUMN_DISCOUNT = 'discount';
+  static const COLUMN_PRODUCT_COST = 'product_cost';
+  static const COLUMN_MARGIN = 'margin';
 
   final _debouncer = Debouncer();
   TextEditingController? _textEditingController;
@@ -233,6 +235,14 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
         _columns.add(COLUMN_DISCOUNT);
       }
     }
+
+    if (!widget.isTasks) {
+      final unitCostIndex = _columns.indexOf(COLUMN_UNIT_COST);
+      if (unitCostIndex >= 0) {
+        _columns.insert(unitCostIndex + 1, COLUMN_PRODUCT_COST);
+        _columns.insert(unitCostIndex + 2, COLUMN_MARGIN);
+      }
+    }
   }
 
   @override
@@ -379,6 +389,12 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
             ? translations['discount']!
             : localization!.discount;
         isNumeric = true;
+      } else if (column == COLUMN_PRODUCT_COST) {
+        label = 'EK';
+        isNumeric = true;
+      } else if (column == COLUMN_MARGIN) {
+        label = 'Marge %';
+        isNumeric = true;
       }
       tableHeaderColumns.add(TableHeader(
         label,
@@ -519,6 +535,28 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
                                           : null,
                                     ) ??
                                     '',
+                                textAlign: TextAlign.right,
+                              );
+                            } else if (column == COLUMN_PRODUCT_COST) {
+                              return Text(
+                                formatNumber(
+                                      item.productCost,
+                                      context,
+                                      formatNumberType:
+                                          FormatNumberType.inputMoney,
+                                      clientId: invoice.isPurchaseOrder
+                                          ? null
+                                          : invoice.clientId,
+                                      vendorId: invoice.isPurchaseOrder
+                                          ? invoice.vendorId
+                                          : null,
+                                    ) ??
+                                    '',
+                                textAlign: TextAlign.right,
+                              );
+                            } else if (column == COLUMN_MARGIN) {
+                              return Text(
+                                '${item.margin.toStringAsFixed(1)} %',
                                 textAlign: TextAlign.right,
                               );
                             }
@@ -1092,6 +1130,75 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
                                 index,
                                 debounce: false,
                               ),
+                              keyboardType: TextInputType.numberWithOptions(
+                                  decimal: true, signed: true),
+                              onSavePressed:
+                                  widget.entityViewModel.onSavePressed,
+                            ),
+                          ),
+                        );
+                      } else if (column == COLUMN_PRODUCT_COST) {
+                        return Focus(
+                          onFocusChange: (hasFocus) => _onFocusChange(),
+                          skipTraversal: true,
+                          child: Padding(
+                            padding:
+                                const EdgeInsets.only(right: kTableColumnGap),
+                            child: DecoratedFormField(
+                              key: ValueKey(
+                                  '__line_item_${index}_product_cost__'),
+                              textAlign: TextAlign.right,
+                              initialValue: formatNumber(
+                                lineItems[index].productCost,
+                                context,
+                                formatNumberType: FormatNumberType.inputMoney,
+                                clientId: invoice.isPurchaseOrder
+                                    ? null
+                                    : invoice.clientId,
+                                vendorId: invoice.isPurchaseOrder
+                                    ? invoice.vendorId
+                                    : null,
+                              ),
+                              onChanged: (value) => _onChanged(
+                                lineItems[index].rebuild((b) =>
+                                    b..productCost = parseDouble(value)),
+                                index,
+                                debounce: false,
+                              ),
+                              keyboardType: TextInputType.numberWithOptions(
+                                  decimal: true, signed: true),
+                              onSavePressed:
+                                  widget.entityViewModel.onSavePressed,
+                            ),
+                          ),
+                        );
+                      } else if (column == COLUMN_MARGIN) {
+                        final item = lineItems[index];
+                        return Focus(
+                          onFocusChange: (hasFocus) => _onFocusChange(),
+                          skipTraversal: true,
+                          child: Padding(
+                            padding:
+                                const EdgeInsets.only(right: kTableColumnGap),
+                            child: DecoratedFormField(
+                              key: ValueKey(
+                                  '__line_item_${index}_margin_${item.productCost}_${item.cost}__'),
+                              textAlign: TextAlign.right,
+                              initialValue: formatNumber(
+                                item.margin,
+                                context,
+                                formatNumberType: FormatNumberType.inputAmount,
+                              ),
+                              onChanged: (value) {
+                                final margin = parseDouble(value) ?? 0;
+                                final ek = InvoiceItemEntity.calcEK(
+                                    lineItems[index].cost, margin);
+                                _onChanged(
+                                  lineItems[index].rebuild(
+                                      (b) => b..productCost = ek),
+                                  index,
+                                );
+                              },
                               keyboardType: TextInputType.numberWithOptions(
                                   decimal: true, signed: true),
                               onSavePressed:

--- a/lib/ui/invoice/edit/invoice_edit_items_desktop.dart
+++ b/lib/ui/invoice/edit/invoice_edit_items_desktop.dart
@@ -62,6 +62,7 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
   static const COLUMN_DISCOUNT = 'discount';
   static const COLUMN_PRODUCT_COST = 'product_cost';
   static const COLUMN_MARGIN = 'margin';
+  static const COLUMN_RENTAL_DAYS = 'rental_days';
 
   final _debouncer = Debouncer();
   TextEditingController? _textEditingController;
@@ -239,8 +240,9 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
     if (!widget.isTasks) {
       final unitCostIndex = _columns.indexOf(COLUMN_UNIT_COST);
       if (unitCostIndex >= 0) {
-        _columns.insert(unitCostIndex + 1, COLUMN_PRODUCT_COST);
-        _columns.insert(unitCostIndex + 2, COLUMN_MARGIN);
+        _columns.insert(unitCostIndex + 1, COLUMN_RENTAL_DAYS);
+        _columns.insert(unitCostIndex + 2, COLUMN_PRODUCT_COST);
+        _columns.insert(unitCostIndex + 3, COLUMN_MARGIN);
       }
     }
   }
@@ -389,6 +391,9 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
             ? translations['discount']!
             : localization!.discount;
         isNumeric = true;
+      } else if (column == COLUMN_RENTAL_DAYS) {
+        label = 'Miettage';
+        isNumeric = true;
       } else if (column == COLUMN_PRODUCT_COST) {
         label = 'EK';
         isNumeric = true;
@@ -533,6 +538,17 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
                                       vendorId: invoice.isPurchaseOrder
                                           ? invoice.vendorId
                                           : null,
+                                    ) ??
+                                    '',
+                                textAlign: TextAlign.right,
+                              );
+                            } else if (column == COLUMN_RENTAL_DAYS) {
+                              return Text(
+                                formatNumber(
+                                      item.rentalDays,
+                                      context,
+                                      formatNumberType:
+                                          FormatNumberType.inputAmount,
                                     ) ??
                                     '',
                                 textAlign: TextAlign.right,
@@ -1201,6 +1217,35 @@ class _InvoiceEditItemsDesktopState extends State<InvoiceEditItemsDesktop> {
                               },
                               keyboardType: TextInputType.numberWithOptions(
                                   decimal: true, signed: true),
+                              onSavePressed:
+                                  widget.entityViewModel.onSavePressed,
+                            ),
+                          ),
+                        );
+                      } else if (column == COLUMN_RENTAL_DAYS) {
+                        return Focus(
+                          onFocusChange: (hasFocus) => _onFocusChange(),
+                          skipTraversal: true,
+                          child: Padding(
+                            padding:
+                                const EdgeInsets.only(right: kTableColumnGap),
+                            child: DecoratedFormField(
+                              key: ValueKey(
+                                  '__line_item_${index}_rental_days__'),
+                              textAlign: TextAlign.right,
+                              initialValue: formatNumber(
+                                lineItems[index].rentalDays,
+                                context,
+                                formatNumberType: FormatNumberType.inputAmount,
+                              ),
+                              onChanged: (value) => _onChanged(
+                                lineItems[index].rebuild((b) =>
+                                    b..rentalDays = parseDouble(value) ?? 1),
+                                index,
+                                debounce: false,
+                              ),
+                              keyboardType: TextInputType.numberWithOptions(
+                                  decimal: true),
                               onSavePressed:
                                   widget.entityViewModel.onSavePressed,
                             ),

--- a/lib/utils/super_editor/toolbar.dart
+++ b/lib/utils/super_editor/toolbar.dart
@@ -73,7 +73,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
   void initState() {
     super.initState();
 
-    _toolbarAligner = CupertinoPopoverToolbarAligner(widget.editorViewportKey);
+    _toolbarAligner = CupertinoPopoverToolbarAligner();
 
     _popoverFocusNode = FocusNode();
 
@@ -90,7 +90,6 @@ class _EditorToolbarState extends State<EditorToolbar> {
 
     _screenBoundary = WidgetFollowerBoundary(
       boundaryKey: widget.editorViewportKey,
-      devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "8.4.1"
   archive:
     dependency: "direct main"
     description:
@@ -45,11 +45,11 @@ packages:
     dependency: "direct overridden"
     description:
       path: attributed_text
-      ref: stable
-      resolved-ref: a1526c5576761a76cbfbfcf27f54515c60d30ce3
+      ref: "9655c7f9"
+      resolved-ref: "9655c7f987968d680f83fc095a604f86d9ad15a1"
       url: "https://github.com/superlistapp/super_editor"
     source: git
-    version: "0.3.2"
+    version: "0.4.5"
   barcode:
     dependency: transitive
     description:
@@ -159,10 +159,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -271,10 +271,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   dbus:
     dependency: transitive
     description:
@@ -504,10 +504,10 @@ packages:
     dependency: "direct main"
     description:
       name: follow_the_leader
-      sha256: "798baf5211ca2461c8462d4c8e94f57bf989758f8204056d607eb9a20f1cf794"
+      sha256: "2e4c4ebe6b3f1942b2385904b118ba8ba117fae0b30c8c453be0b64a271dd07a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.4+8"
+    version: "0.5.2"
   frontend_server_client:
     dependency: transitive
     description:
@@ -933,18 +933,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_design_icons_flutter:
     dependency: "direct main"
     description:
@@ -965,10 +965,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1037,10 +1037,10 @@ packages:
     dependency: "direct main"
     description:
       name: overlord
-      sha256: "576256bc9ce3fb0ae3042bbb26eed67bdb26a5045dd7e3c851aae65b0bbab2f5"
+      sha256: "532f5685ac09ee805d97ce89794a4eeda41672c32955b4a835bdfce93e720a05"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.3+5"
+    version: "0.4.2"
   package_config:
     dependency: transitive
     description:
@@ -1596,37 +1596,37 @@ packages:
     dependency: "direct main"
     description:
       path: super_editor
-      ref: stable
-      resolved-ref: a1526c5576761a76cbfbfcf27f54515c60d30ce3
+      ref: "9655c7f9"
+      resolved-ref: "9655c7f987968d680f83fc095a604f86d9ad15a1"
       url: "https://github.com/superlistapp/super_editor"
     source: git
-    version: "0.3.0-dev.10"
+    version: "0.3.0-dev.39"
   super_editor_markdown:
     dependency: "direct main"
     description:
       path: super_editor_markdown
-      ref: stable
-      resolved-ref: a1526c5576761a76cbfbfcf27f54515c60d30ce3
+      ref: "9655c7f9"
+      resolved-ref: "9655c7f987968d680f83fc095a604f86d9ad15a1"
       url: "https://github.com/superlistapp/super_editor"
     source: git
-    version: "0.1.5"
+    version: "0.2.0"
   super_keyboard:
     dependency: transitive
     description:
       name: super_keyboard
-      sha256: "1a0a32dd799118554fb801822ae2eed7669fbbf7c754d94d240ec3e8ee7dbd67"
+      sha256: "47dfacfd617f7b704c3b9cc786930ced3b6e8698cb5ffd3b4a0cb705d42f679a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.3.1"
   super_text_layout:
     dependency: "direct overridden"
     description:
       path: super_text_layout
-      ref: stable
-      resolved-ref: a1526c5576761a76cbfbfcf27f54515c60d30ce3
+      ref: "9655c7f9"
+      resolved-ref: "9655c7f987968d680f83fc095a604f86d9ad15a1"
       url: "https://github.com/superlistapp/super_editor"
     source: git
-    version: "0.1.15"
+    version: "0.1.19"
   sync_http:
     dependency: transitive
     description:
@@ -1647,26 +1647,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.16"
   timeago:
     dependency: "direct main"
     description:
@@ -1956,5 +1956,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -151,10 +151,10 @@ packages:
     dependency: "direct dev"
     description:
       name: built_value_generator
-      sha256: "82281895e5347dd70ffd3aab2756f39d52b55c945fa0efa635ad6d643dae5833"
+      sha256: e5d1374e35a163507037733a9a0902f88647b8869b487fd66ae915da4e91ff8f
       url: "https://pub.dev"
     source: hosted
-    version: "8.11.1"
+    version: "8.12.2"
   characters:
     dependency: transitive
     description:
@@ -1516,10 +1516,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
+      sha256: "732792cfd197d2161a65bb029606a46e0a18ff30ef9e141a7a82172b05ea8ecd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.2.2"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,26 +106,22 @@ dependency_overrides:
     git:
       url: https://github.com/superlistapp/super_editor
       path: super_editor
-      #ref: c75f59a7aca9139bb6b38001c705ac430d5d2946
-      ref: stable
+      ref: 9655c7f9
   super_editor_markdown:
     git:
       url: https://github.com/superlistapp/super_editor
       path: super_editor_markdown
-      #ref: c75f59a7aca9139bb6b38001c705ac430d5d2946
-      ref: stable
+      ref: 9655c7f9
   super_text_layout:
     git:
       url: https://github.com/superlistapp/super_editor
       path: super_text_layout
-      #ref: c75f59a7aca9139bb6b38001c705ac430d5d2946
-      ref: stable
+      ref: 9655c7f9
   attributed_text:
     git:
       url: https://github.com/superlistapp/super_editor
       path: attributed_text
-      #ref: c75f59a7aca9139bb6b38001c705ac430d5d2946
-      ref: stable
+      ref: 9655c7f9
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
## Summary
- Neues Feld `rental_days` (Miettage) pro Invoice-Zeile: `Zeilengesamt = Einzelpreis × Miettage × Menge`
- Desktop-Editor: neue Spalte „Miettage" nach Einzelpreis
- Mobiler Dialog: neues Formularfeld „Miettage" (nur für Nicht-Task-Items)
- Default-Wert 1 → bestehende Rechnungen unverändert

## Test Plan
- [ ] Neues Angebot erstellen → Zeile hinzufügen → Miettage z.B. 5 eingeben → Zeilengesamt = Einzelpreis × 5 × Menge
- [ ] Speichern + neu laden → Miettage bleibt erhalten
- [ ] Bestehende Angebote ohne Miettage → Zeilensummen unverändert (Default=1)
- [ ] Desktop und Mobile jeweils testen

## Backend
Zugehörige Backend-Änderungen im Fork `MathisScholz/invoiceninja` auf Branch `feature/miettage-multiplikator`:
- Migration: `rental_days DECIMAL(8,2) DEFAULT 1`
- DataMapper + Zeilensummen-Berechnung (InvoiceItemSum + Inclusive)
- PDF-Spalte registriert (`$product.rental_days`)