### PR TITLE
Added EntityHeader with Participant and ParticipantName in View Transaction Detail

### DIFF
--- a/lib/ui/transaction/view/transaction_view.dart
+++ b/lib/ui/transaction/view/transaction_view.dart
@@ -82,6 +82,16 @@ class _TransactionViewState extends State<TransactionView> {
                   ),
                   ListDivider(),
                 ],
+                if (transactions.length == 1 && transaction.participant.isNotEmpty && transaction.participantName.isNotEmpty) ...[
+                  EntityHeader(
+                    entity: transaction,
+                    label: localization!.participant,
+                    value: transaction.participant,
+                    secondLabel: localization.participantName,
+                    secondValue: transaction.participantName,
+                  ),
+                  ListDivider(),
+                ],
                 if (transaction.isConverted) ...[
                   if (transaction.formattedDescription.isNotEmpty) ...[
                     IconMessage(transaction.formattedDescription,


### PR DESCRIPTION
When viewing a Transaction the participant and participant name are also added as an EntityHeader widget below the amount and transaction date.