### PR TITLE
Fix sticky header alignment, localized width estimation, caching, and redundant row generation in AppPaginatedDataTable

### DIFF
--- a/lib/ui/app/tables/app_paginated_data_table.dart
+++ b/lib/ui/app/tables/app_paginated_data_table.dart
@@ -285,6 +285,11 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
   int _selectedRowCount = 0;
   final Map<int, DataRow?> _rows = <int, DataRow?>{};
 
+  List<double>? _cachedColumnWidths;
+  int? _cachedFirstRowIndex;
+  int? _cachedColumnsLength;
+  Object? _cachedSource;
+
 
 
   void _handleDataSourceChanged() {
@@ -293,6 +298,7 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
       _rowCountApproximate = widget.source.isRowCountApproximate;
       _selectedRowCount = widget.source.selectedRowCount;
       _rows.clear();
+      _cachedColumnWidths = null;
     });
   }
 
@@ -392,6 +398,9 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
       widget.source.addListener(_handleDataSourceChanged);
       _handleDataSourceChanged();
     }
+    if (oldWidget.columns.length != widget.columns.length) {
+      _cachedColumnWidths = null;
+    }
   }
 
   @override
@@ -404,7 +413,106 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
     super.dispose();
   }
 
-  List<double> _calculateColumnWidths(BuildContext context) {
+  Widget? _findTextWidget(Widget widget) {
+    if (widget is Text || widget is RichText) {
+      return widget;
+    }
+    if (widget is Container) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is Padding) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is SizedBox) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is ConstrainedBox) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is Center) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is Align) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is Expanded) {
+      return _findTextWidget(widget.child);
+    }
+    if (widget is Flexible) {
+      return _findTextWidget(widget.child);
+    }
+    if (widget is Tooltip) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is GestureDetector) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    if (widget is InkWell) {
+      if (widget.child != null) {
+        return _findTextWidget(widget.child!);
+      }
+    }
+    return null;
+  }
+
+  double _measureWidgetText(BuildContext context, Widget rootWidget, TextStyle defaultStyle) {
+    final Widget? textWidget = _findTextWidget(rootWidget);
+    if (textWidget == null) {
+      return 0.0;
+    }
+    if (textWidget is RichText) {
+      final TextPainter textPainter = TextPainter(
+        text: textWidget.text,
+        maxLines: textWidget.maxLines,
+        textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+      )..layout(minWidth: 0, maxWidth: double.infinity);
+      return textPainter.size.width;
+    }
+    if (textWidget is Text) {
+      final String text = textWidget.data ?? '';
+      if (text.isEmpty) {
+        return 0.0;
+      }
+      TextStyle style = defaultStyle;
+      if (textWidget.style != null) {
+        style = defaultStyle.merge(textWidget.style);
+      }
+      final TextPainter textPainter = TextPainter(
+        text: TextSpan(text: text, style: style),
+        maxLines: textWidget.maxLines ?? 1,
+        textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+      )..layout(minWidth: 0, maxWidth: double.infinity);
+      return textPainter.size.width;
+    }
+    return 0.0;
+  }
+
+  List<double> _calculateColumnWidths(BuildContext context, List<DataRow> originalRows) {
+    final ThemeData themeData = Theme.of(context);
+    final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
+    final TextStyle headingStyle = dataTableTheme.headingTextStyle ??
+        themeData.textTheme.titleSmall ??
+        const TextStyle();
+    final TextStyle dataStyle = dataTableTheme.dataTextStyle ??
+        themeData.textTheme.bodyMedium ??
+        const TextStyle();
+
     final List<double> resolvedWidths = [];
     for (int i = 0; i < widget.columns.length; i++) {
       double minW = 0.0;
@@ -416,33 +524,36 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
         maxW = math.min(maxW, max);
       });
 
-      final sampleRows = _getRows(_firstRowIndex, math.min(5, widget.rowsPerPage));
+      double maxTextWidth = _measureWidgetText(context, column.label, headingStyle);
+
+      final sampleRows = originalRows.take(5).toList();
       for (final row in sampleRows) {
         if (i < row.cells.length) {
-          _updateConstraints(row.cells[i].child, (min, max) {
+          final cellChild = row.cells[i].child;
+          _updateConstraints(cellChild, (min, max) {
             minW = math.max(minW, min);
             maxW = math.min(maxW, max);
           });
+          final cellTextWidth = _measureWidgetText(context, cellChild, dataStyle);
+          maxTextWidth = math.max(maxTextWidth, cellTextWidth);
         }
       }
 
-      double width = 140.0;
+      double estimatedWidth = maxTextWidth + 32.0;
+      if (column.onSort != null) {
+        estimatedWidth += 24.0;
+      }
+
+      double width = math.max(140.0, estimatedWidth);
       if (minW > 0.0) {
-        width = minW;
+        width = math.max(width, minW);
       }
       if (maxW < double.infinity && maxW > 0.0) {
         width = math.min(width, maxW);
       }
 
-      if (column.label is Text) {
-        final text = (column.label as Text).data ?? '';
-        width = _guessWidthFromText(text, width);
-      } else if (column.label is Container && (column.label as Container).child is Text) {
-        final text = ((column.label as Container).child as Text).data ?? '';
-        width = _guessWidthFromText(text, width);
-      }
-
-      if (column.label is SizedBox || (column.label is Container && (column.label as Container).child == null)) {
+      if (column.label is SizedBox ||
+          (column.label is Container && (column.label as Container).child == null)) {
         width = 96.0;
       }
 
@@ -474,23 +585,18 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
     }
   }
 
-  double _guessWidthFromText(String text, double currentWidth) {
-    final lowerText = text.toLowerCase();
-    double width = currentWidth;
-    if (lowerText.contains('description') || lowerText.contains('notes') || lowerText.contains('details')) {
-      width = math.max(width, 260.0);
-    } else if (lowerText.contains('amount') || lowerText.contains('price') || lowerText.contains('total') || lowerText.contains('balance')) {
-      width = math.max(width, 120.0);
-    } else if (lowerText.contains('date')) {
-      width = math.max(width, 110.0);
-    } else if (lowerText.contains('number') || lowerText.contains('id') || lowerText.contains('status')) {
-      width = math.max(width, 100.0);
-    } else {
-      width = math.max(width, 140.0);
+  List<double> _getColumnWidths(BuildContext context, List<DataRow> originalRows) {
+    if (_cachedColumnWidths != null &&
+        _cachedFirstRowIndex == _firstRowIndex &&
+        _cachedColumnsLength == widget.columns.length &&
+        _cachedSource == widget.source) {
+      return _cachedColumnWidths!;
     }
-    final estimatedTextWidth = text.length * 8.0 + 32.0;
-    width = math.max(width, estimatedTextWidth);
-    return width;
+    _cachedColumnWidths = _calculateColumnWidths(context, originalRows);
+    _cachedFirstRowIndex = _firstRowIndex;
+    _cachedColumnsLength = widget.columns.length;
+    _cachedSource = widget.source;
+    return _cachedColumnWidths!;
   }
 
   Widget _buildHeader(ThemeData themeData, MaterialLocalizations localizations, List<Widget> headerWidgets) {
@@ -513,7 +619,7 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
                 : null,
             child: Padding(
               padding: const EdgeInsetsDirectional.only(
-                  start: 24, end: 14.0),
+                  start: 24, end: 14.0), // to match trailing padding in case we overflow and end up scrolling
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: headerWidgets,
@@ -549,6 +655,7 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
 
   @override
   Widget build(BuildContext context) {
+    // TODO(ianh): This whole build function doesn't handle RTL yet.
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData themeData = Theme.of(context);
     final MaterialLocalizations localizations =
@@ -591,7 +698,7 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
         Container(width: 14.0),
         Text(localizations.rowsPerPageTitle),
         ConstrainedBox(
-          constraints: const BoxConstraints(minWidth: 64.0),
+          constraints: const BoxConstraints(minWidth: 64.0), // 40.0 for the text, 24.0 for the icon
           child: Align(
             alignment: AlignmentDirectional.centerEnd,
             child: DropdownButtonHideUnderline(
@@ -658,7 +765,21 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
 
           Widget tableWidget;
           if (useScrollableLayout) {
-            final List<double> columnWidths = _calculateColumnWidths(context);
+            final List<DataRow> originalRows = _getRows(_firstRowIndex, widget.rowsPerPage);
+            final List<double> columnWidths = _getColumnWidths(context, originalRows);
+            final bool hasSelectableRows = originalRows.any((row) => row.onSelectChanged != null);
+            final List<DataRow> headerDummyRows = hasSelectableRows
+                ? <DataRow>[
+                    DataRow(
+                      onSelectChanged: (bool? selected) {},
+                      cells: List<DataCell>.filled(
+                        widget.columns.length,
+                        const DataCell(SizedBox.shrink()),
+                      ),
+                    ),
+                  ]
+                : const <DataRow>[];
+
             // Build header columns
             final List<DataColumn> headerColumns = [];
             for (int i = 0; i < widget.columns.length; i++) {
@@ -678,7 +799,6 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
 
             // Build body rows
             final List<DataRow> bodyRows = [];
-            final List<DataRow> originalRows = _getRows(_firstRowIndex, widget.rowsPerPage);
             for (final row in originalRows) {
               final List<DataCell> cells = [];
               for (int i = 0; i < row.cells.length; i++) {
@@ -737,21 +857,26 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: <Widget>[
-                              DataTable(
-                                columns: headerColumns,
-                                sortColumnIndex: widget.sortColumnIndex,
-                                sortAscending: widget.sortAscending,
-                                onSelectAll: widget.onSelectAll,
-                                decoration: const BoxDecoration(),
-                                dataRowMinHeight: widget.dataRowMinHeight,
-                                dataRowMaxHeight: widget.dataRowMaxHeight,
-                                headingRowHeight: widget.headingRowHeight,
-                                horizontalMargin: widget.horizontalMargin,
-                                checkboxHorizontalMargin: widget.checkboxHorizontalMargin,
-                                columnSpacing: widget.columnSpacing,
-                                showCheckboxColumn: widget.showCheckboxColumn,
-                                showBottomBorder: true,
-                                rows: const <DataRow>[],
+                              ClipRect(
+                                child: SizedBox(
+                                  height: widget.headingRowHeight,
+                                  child: DataTable(
+                                    columns: headerColumns,
+                                    sortColumnIndex: widget.sortColumnIndex,
+                                    sortAscending: widget.sortAscending,
+                                    onSelectAll: widget.onSelectAll,
+                                    decoration: const BoxDecoration(),
+                                    dataRowMinHeight: widget.dataRowMinHeight,
+                                    dataRowMaxHeight: widget.dataRowMaxHeight,
+                                    headingRowHeight: widget.headingRowHeight,
+                                    horizontalMargin: widget.horizontalMargin,
+                                    checkboxHorizontalMargin: widget.checkboxHorizontalMargin,
+                                    columnSpacing: widget.columnSpacing,
+                                    showCheckboxColumn: widget.showCheckboxColumn,
+                                    showBottomBorder: true,
+                                    rows: headerDummyRows,
+                                  ),
+                                ),
                               ),
                               Expanded(
                                 child: SingleChildScrollView(
@@ -761,8 +886,8 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
                                   child: DataTable(
                                     key: _tableKey,
                                     columns: headerColumns,
-                                    sortColumnIndex: widget.sortColumnIndex,
-                                    sortAscending: widget.sortAscending,
+                                    sortColumnIndex: null,
+                                    sortAscending: true,
                                     onSelectAll: null,
                                     decoration: const BoxDecoration(),
                                     dataRowMinHeight: widget.dataRowMinHeight,

--- a/lib/ui/app/tables/app_paginated_data_table.dart
+++ b/lib/ui/app/tables/app_paginated_data_table.dart
@@ -285,35 +285,7 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
   int _selectedRowCount = 0;
   final Map<int, DataRow?> _rows = <int, DataRow?>{};
 
-  @override
-  void initState() {
-    super.initState();
-    _firstRowIndex = PageStorage.maybeOf(context)?.readState(context) as int? ??
-        widget.initialFirstRowIndex ??
-        0;
-    widget.source.addListener(_handleDataSourceChanged);
-    _handleDataSourceChanged();
-    _controller = widget.controller ?? ScrollController();
-  }
 
-  @override
-  void didUpdateWidget(AppPaginatedDataTable oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.source != widget.source) {
-      oldWidget.source.removeListener(_handleDataSourceChanged);
-      widget.source.addListener(_handleDataSourceChanged);
-      _handleDataSourceChanged();
-    }
-  }
-
-  @override
-  void dispose() {
-    widget.source.removeListener(_handleDataSourceChanged);
-    if (widget.controller == null) {
-      _controller.dispose();
-    }
-    super.dispose();
-  }
 
   void _handleDataSourceChanged() {
     setState(() {
@@ -398,14 +370,190 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
       (_firstRowIndex + widget.rowsPerPage >= _rowCount);
 
   final GlobalKey _tableKey = GlobalKey();
+  late ScrollController _verticalScrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _firstRowIndex = PageStorage.maybeOf(context)?.readState(context) as int? ??
+        widget.initialFirstRowIndex ??
+        0;
+    widget.source.addListener(_handleDataSourceChanged);
+    _handleDataSourceChanged();
+    _controller = widget.controller ?? ScrollController();
+    _verticalScrollController = ScrollController();
+  }
+
+  @override
+  void didUpdateWidget(AppPaginatedDataTable oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.source != widget.source) {
+      oldWidget.source.removeListener(_handleDataSourceChanged);
+      widget.source.addListener(_handleDataSourceChanged);
+      _handleDataSourceChanged();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.source.removeListener(_handleDataSourceChanged);
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    _verticalScrollController.dispose();
+    super.dispose();
+  }
+
+  List<double> _calculateColumnWidths(BuildContext context) {
+    final List<double> resolvedWidths = [];
+    for (int i = 0; i < widget.columns.length; i++) {
+      double minW = 0.0;
+      double maxW = double.infinity;
+
+      final column = widget.columns[i];
+      _updateConstraints(column.label, (min, max) {
+        minW = math.max(minW, min);
+        maxW = math.min(maxW, max);
+      });
+
+      final sampleRows = _getRows(_firstRowIndex, math.min(5, widget.rowsPerPage));
+      for (final row in sampleRows) {
+        if (i < row.cells.length) {
+          _updateConstraints(row.cells[i].child, (min, max) {
+            minW = math.max(minW, min);
+            maxW = math.min(maxW, max);
+          });
+        }
+      }
+
+      double width = 140.0;
+      if (minW > 0.0) {
+        width = minW;
+      }
+      if (maxW < double.infinity && maxW > 0.0) {
+        width = math.min(width, maxW);
+      }
+
+      if (column.label is Text) {
+        final text = (column.label as Text).data ?? '';
+        width = _guessWidthFromText(text, width);
+      } else if (column.label is Container && (column.label as Container).child is Text) {
+        final text = ((column.label as Container).child as Text).data ?? '';
+        width = _guessWidthFromText(text, width);
+      }
+
+      if (column.label is SizedBox || (column.label is Container && (column.label as Container).child == null)) {
+        width = 96.0;
+      }
+
+      resolvedWidths.add(width);
+    }
+    return resolvedWidths;
+  }
+
+  void _updateConstraints(Widget widget, void Function(double min, double max) onConstraints) {
+    if (widget is ConstrainedBox) {
+      onConstraints(widget.constraints.minWidth, widget.constraints.maxWidth);
+      if (widget.child != null) {
+        _updateConstraints(widget.child!, onConstraints);
+      }
+    } else if (widget is Container) {
+      if (widget.constraints != null) {
+        onConstraints(widget.constraints!.minWidth, widget.constraints!.maxWidth);
+      }
+      if (widget.child != null) {
+        _updateConstraints(widget.child!, onConstraints);
+      }
+    } else if (widget is SizedBox) {
+      if (widget.width != null) {
+        onConstraints(widget.width!, widget.width!);
+      }
+      if (widget.child != null) {
+        _updateConstraints(widget.child!, onConstraints);
+      }
+    }
+  }
+
+  double _guessWidthFromText(String text, double currentWidth) {
+    final lowerText = text.toLowerCase();
+    double width = currentWidth;
+    if (lowerText.contains('description') || lowerText.contains('notes') || lowerText.contains('details')) {
+      width = math.max(width, 260.0);
+    } else if (lowerText.contains('amount') || lowerText.contains('price') || lowerText.contains('total') || lowerText.contains('balance')) {
+      width = math.max(width, 120.0);
+    } else if (lowerText.contains('date')) {
+      width = math.max(width, 110.0);
+    } else if (lowerText.contains('number') || lowerText.contains('id') || lowerText.contains('status')) {
+      width = math.max(width, 100.0);
+    } else {
+      width = math.max(width, 140.0);
+    }
+    final estimatedTextWidth = text.length * 8.0 + 32.0;
+    width = math.max(width, estimatedTextWidth);
+    return width;
+  }
+
+  Widget _buildHeader(ThemeData themeData, MaterialLocalizations localizations, List<Widget> headerWidgets) {
+    return Semantics(
+      container: true,
+      child: DefaultTextStyle(
+        style: _selectedRowCount > 0
+            ? themeData.textTheme.titleMedium!
+                .copyWith(color: themeData.colorScheme.secondary)
+            : themeData.textTheme.titleLarge!
+                .copyWith(fontWeight: FontWeight.w400),
+        child: IconTheme.merge(
+          data: const IconThemeData(
+            opacity: 0.54,
+          ),
+          child: Ink(
+            height: 64.0,
+            color: _selectedRowCount > 0
+                ? themeData.secondaryHeaderColor
+                : null,
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(
+                  start: 24, end: 14.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: headerWidgets,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFooter(TextStyle? footerTextStyle, List<Widget> footerWidgets) {
+    return DefaultTextStyle(
+      style: footerTextStyle!,
+      child: IconTheme.merge(
+        data: const IconThemeData(
+          opacity: 0.54,
+        ),
+        child: SizedBox(
+          height: 56.0,
+          child: SingleChildScrollView(
+            dragStartBehavior: widget.dragStartBehavior,
+            scrollDirection: Axis.horizontal,
+            reverse: true,
+            child: Row(
+              children: footerWidgets,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    // TODO(ianh): This whole build function doesn't handle RTL yet.
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData themeData = Theme.of(context);
     final MaterialLocalizations localizations =
         MaterialLocalizations.of(context);
+
     // HEADER
     final List<Widget> headerWidgets = <Widget>[];
     if (_selectedRowCount == 0 && widget.header != null) {
@@ -419,7 +567,6 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
       headerWidgets.addAll(
         widget.actions!.map<Widget>((Widget action) {
           return Padding(
-            // 8.0 is the default padding of an icon button
             padding: const EdgeInsetsDirectional.only(start: 24.0 - 8.0 * 2.0),
             child: action,
           );
@@ -434,7 +581,6 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
         math.min(_rowCount, _firstRowIndex + widget.rowsPerPage);
     if (widget.onRowsPerPageChanged != null) {
       final List<Widget> availableRowsPerPage = widget.availableRowsPerPage
-          //.where((int value) => value <= _rowCount || value == widget.rowsPerPage)
           .map<DropdownMenuItem<int>>((int value) {
         return DropdownMenuItem<int>(
           value: value,
@@ -442,13 +588,10 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
         );
       }).toList();
       footerWidgets.addAll(<Widget>[
-        Container(
-            width:
-                14.0), // to match trailing padding in case we overflow and end up scrolling
+        Container(width: 14.0),
         Text(localizations.rowsPerPageTitle),
         ConstrainedBox(
-          constraints: const BoxConstraints(
-              minWidth: 64.0), // 40.0 for the text, 24.0 for the icon
+          constraints: const BoxConstraints(minWidth: 64.0),
           child: Align(
             alignment: AlignmentDirectional.centerEnd,
             child: DropdownButtonHideUnderline(
@@ -511,96 +654,181 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
       semanticContainer: false,
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              if (headerWidgets.isNotEmpty)
-                Semantics(
-                  container: true,
-                  child: DefaultTextStyle(
-                    // These typographic styles aren't quite the regular ones. We pick the closest ones from the regular
-                    // list and then tweak them appropriately.
-                    // See https://material.io/design/components/data-tables.html#tables-within-cards
-                    style: _selectedRowCount > 0
-                        ? themeData.textTheme.titleMedium!
-                            .copyWith(color: themeData.colorScheme.secondary)
-                        : themeData.textTheme.titleLarge!
-                            .copyWith(fontWeight: FontWeight.w400),
-                    child: IconTheme.merge(
-                      data: const IconThemeData(
-                        opacity: 0.54,
-                      ),
-                      child: Ink(
-                        height: 64.0,
-                        color: _selectedRowCount > 0
-                            ? themeData.secondaryHeaderColor
-                            : null,
-                        child: Padding(
-                          padding: const EdgeInsetsDirectional.only(
-                              start: 24, end: 14.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: headerWidgets,
+          final bool useScrollableLayout = constraints.hasBoundedHeight;
+
+          Widget tableWidget;
+          if (useScrollableLayout) {
+            final List<double> columnWidths = _calculateColumnWidths(context);
+            // Build header columns
+            final List<DataColumn> headerColumns = [];
+            for (int i = 0; i < widget.columns.length; i++) {
+              final col = widget.columns[i];
+              headerColumns.add(
+                DataColumn(
+                  label: SizedBox(
+                    width: columnWidths[i],
+                    child: col.label,
+                  ),
+                  tooltip: col.tooltip,
+                  numeric: col.numeric,
+                  onSort: col.onSort,
+                ),
+              );
+            }
+
+            // Build body rows
+            final List<DataRow> bodyRows = [];
+            final List<DataRow> originalRows = _getRows(_firstRowIndex, widget.rowsPerPage);
+            for (final row in originalRows) {
+              final List<DataCell> cells = [];
+              for (int i = 0; i < row.cells.length; i++) {
+                final cell = row.cells[i];
+                final width = i < columnWidths.length ? columnWidths[i] : 140.0;
+                cells.add(
+                  DataCell(
+                    SizedBox(
+                      width: width,
+                      child: cell.child,
+                    ),
+                    placeholder: cell.placeholder,
+                    showEditIcon: cell.showEditIcon,
+                    onTap: cell.onTap,
+                    onLongPress: cell.onLongPress,
+                    onTapDown: cell.onTapDown,
+                    onDoubleTap: cell.onDoubleTap,
+                    onTapCancel: cell.onTapCancel,
+                  ),
+                );
+              }
+              bodyRows.add(
+                DataRow(
+                  key: row.key,
+                  selected: row.selected,
+                  onSelectChanged: row.onSelectChanged,
+                  onLongPress: row.onLongPress,
+                  color: row.color,
+                  cells: cells,
+                ),
+              );
+            }
+
+            tableWidget = Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                if (headerWidgets.isNotEmpty)
+                  _buildHeader(themeData, localizations, headerWidgets),
+                Expanded(
+                  child: Scrollbar(
+                    controller: _verticalScrollController,
+                    thumbVisibility: true,
+                    notificationPredicate: (ScrollNotification notification) =>
+                        notification.metrics.axis == Axis.vertical,
+                    child: Scrollbar(
+                      controller: _controller,
+                      thumbVisibility: true,
+                      notificationPredicate: (ScrollNotification notification) =>
+                          notification.metrics.axis == Axis.horizontal,
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        controller: _controller,
+                        dragStartBehavior: widget.dragStartBehavior,
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(minWidth: constraints.minWidth),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              DataTable(
+                                columns: headerColumns,
+                                sortColumnIndex: widget.sortColumnIndex,
+                                sortAscending: widget.sortAscending,
+                                onSelectAll: widget.onSelectAll,
+                                decoration: const BoxDecoration(),
+                                dataRowMinHeight: widget.dataRowMinHeight,
+                                dataRowMaxHeight: widget.dataRowMaxHeight,
+                                headingRowHeight: widget.headingRowHeight,
+                                horizontalMargin: widget.horizontalMargin,
+                                checkboxHorizontalMargin: widget.checkboxHorizontalMargin,
+                                columnSpacing: widget.columnSpacing,
+                                showCheckboxColumn: widget.showCheckboxColumn,
+                                showBottomBorder: true,
+                                rows: const <DataRow>[],
+                              ),
+                              Expanded(
+                                child: SingleChildScrollView(
+                                  scrollDirection: Axis.vertical,
+                                  controller: _verticalScrollController,
+                                  dragStartBehavior: widget.dragStartBehavior,
+                                  child: DataTable(
+                                    key: _tableKey,
+                                    columns: headerColumns,
+                                    sortColumnIndex: widget.sortColumnIndex,
+                                    sortAscending: widget.sortAscending,
+                                    onSelectAll: null,
+                                    decoration: const BoxDecoration(),
+                                    dataRowMinHeight: widget.dataRowMinHeight,
+                                    dataRowMaxHeight: widget.dataRowMaxHeight,
+                                    headingRowHeight: 0.0,
+                                    horizontalMargin: widget.horizontalMargin,
+                                    checkboxHorizontalMargin: widget.checkboxHorizontalMargin,
+                                    columnSpacing: widget.columnSpacing,
+                                    showCheckboxColumn: widget.showCheckboxColumn,
+                                    showBottomBorder: true,
+                                    rows: bodyRows,
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              Scrollbar(
-                controller: _controller,
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  primary: widget.primary,
+                _buildFooter(footerTextStyle, footerWidgets),
+              ],
+            );
+          } else {
+            tableWidget = Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                if (headerWidgets.isNotEmpty)
+                  _buildHeader(themeData, localizations, headerWidgets),
+                Scrollbar(
                   controller: _controller,
-                  dragStartBehavior: widget.dragStartBehavior,
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(minWidth: constraints.minWidth),
-                    child: DataTable(
-                      key: _tableKey,
-                      columns: widget.columns,
-                      sortColumnIndex: widget.sortColumnIndex,
-                      sortAscending: widget.sortAscending,
-                      onSelectAll: widget.onSelectAll,
-                      // Make sure no decoration is set on the DataTable
-                      // from the theme, as its already wrapped in a Card.
-                      decoration: const BoxDecoration(),
-                      dataRowMinHeight: widget.dataRowMinHeight,
-                      dataRowMaxHeight: widget.dataRowMaxHeight,
-                      headingRowHeight: widget.headingRowHeight,
-                      horizontalMargin: widget.horizontalMargin,
-                      checkboxHorizontalMargin: widget.checkboxHorizontalMargin,
-                      columnSpacing: widget.columnSpacing,
-                      showCheckboxColumn: widget.showCheckboxColumn,
-                      showBottomBorder: true,
-                      rows: _getRows(_firstRowIndex, widget.rowsPerPage),
-                    ),
-                  ),
-                ),
-              ),
-              DefaultTextStyle(
-                style: footerTextStyle!,
-                child: IconTheme.merge(
-                  data: const IconThemeData(
-                    opacity: 0.54,
-                  ),
-                  child: SizedBox(
-                    // TODO(bkonyi): this won't handle text zoom correctly,
-                    //  https://github.com/flutter/flutter/issues/48522
-                    height: 56.0,
-                    child: SingleChildScrollView(
-                      dragStartBehavior: widget.dragStartBehavior,
-                      scrollDirection: Axis.horizontal,
-                      reverse: true,
-                      child: Row(
-                        children: footerWidgets,
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    primary: widget.primary,
+                    controller: _controller,
+                    dragStartBehavior: widget.dragStartBehavior,
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(minWidth: constraints.minWidth),
+                      child: DataTable(
+                        key: _tableKey,
+                        columns: widget.columns,
+                        sortColumnIndex: widget.sortColumnIndex,
+                        sortAscending: widget.sortAscending,
+                        onSelectAll: widget.onSelectAll,
+                        decoration: const BoxDecoration(),
+                        dataRowMinHeight: widget.dataRowMinHeight,
+                        dataRowMaxHeight: widget.dataRowMaxHeight,
+                        headingRowHeight: widget.headingRowHeight,
+                        horizontalMargin: widget.horizontalMargin,
+                        checkboxHorizontalMargin: widget.checkboxHorizontalMargin,
+                        columnSpacing: widget.columnSpacing,
+                        showCheckboxColumn: widget.showCheckboxColumn,
+                        showBottomBorder: true,
+                        rows: _getRows(_firstRowIndex, widget.rowsPerPage),
                       ),
                     ),
                   ),
                 ),
-              ),
-            ],
-          );
+                _buildFooter(footerTextStyle, footerWidgets),
+              ],
+            );
+          }
+
+          return tableWidget;
         },
       ),
     );

--- a/lib/ui/app/tables/app_paginated_data_table.dart
+++ b/lib/ui/app/tables/app_paginated_data_table.dart
@@ -398,9 +398,15 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
       widget.source.addListener(_handleDataSourceChanged);
       _handleDataSourceChanged();
     }
-    if (oldWidget.columns.length != widget.columns.length) {
+    if (oldWidget.columns != widget.columns) {
       _cachedColumnWidths = null;
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _cachedColumnWidths = null;
   }
 
   @override
@@ -485,20 +491,35 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
       return textPainter.size.width;
     }
     if (textWidget is Text) {
-      final String text = textWidget.data ?? '';
-      if (text.isEmpty) {
-        return 0.0;
+      final String? text = textWidget.data;
+      final InlineSpan? textSpan = textWidget.textSpan;
+
+      if (text != null) {
+        if (text.isEmpty) {
+          return 0.0;
+        }
+        TextStyle style = defaultStyle;
+        if (textWidget.style != null) {
+          style = defaultStyle.merge(textWidget.style);
+        }
+        final TextPainter textPainter = TextPainter(
+          text: TextSpan(text: text, style: style),
+          maxLines: textWidget.maxLines ?? 1,
+          textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+        )..layout(minWidth: 0, maxWidth: double.infinity);
+        return textPainter.size.width;
+      } else if (textSpan != null) {
+        final TextPainter textPainter = TextPainter(
+          text: TextSpan(
+            style: defaultStyle.merge(textWidget.style),
+            children: [textSpan],
+          ),
+          maxLines: textWidget.maxLines ?? 1,
+          textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+        )..layout(minWidth: 0, maxWidth: double.infinity);
+        return textPainter.size.width;
       }
-      TextStyle style = defaultStyle;
-      if (textWidget.style != null) {
-        style = defaultStyle.merge(textWidget.style);
-      }
-      final TextPainter textPainter = TextPainter(
-        text: TextSpan(text: text, style: style),
-        maxLines: textWidget.maxLines ?? 1,
-        textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
-      )..layout(minWidth: 0, maxWidth: double.infinity);
-      return textPainter.size.width;
+      return 0.0;
     }
     return 0.0;
   }
@@ -801,24 +822,28 @@ class AppPaginatedDataTableState extends State<AppPaginatedDataTable> {
             final List<DataRow> bodyRows = [];
             for (final row in originalRows) {
               final List<DataCell> cells = [];
-              for (int i = 0; i < row.cells.length; i++) {
-                final cell = row.cells[i];
-                final width = i < columnWidths.length ? columnWidths[i] : 140.0;
-                cells.add(
-                  DataCell(
-                    SizedBox(
-                      width: width,
-                      child: cell.child,
+              for (int i = 0; i < widget.columns.length; i++) {
+                if (i < row.cells.length) {
+                  final cell = row.cells[i];
+                  final width = i < columnWidths.length ? columnWidths[i] : 140.0;
+                  cells.add(
+                    DataCell(
+                      SizedBox(
+                        width: width,
+                        child: cell.child,
+                      ),
+                      placeholder: cell.placeholder,
+                      showEditIcon: cell.showEditIcon,
+                      onTap: cell.onTap,
+                      onLongPress: cell.onLongPress,
+                      onTapDown: cell.onTapDown,
+                      onDoubleTap: cell.onDoubleTap,
+                      onTapCancel: cell.onTapCancel,
                     ),
-                    placeholder: cell.placeholder,
-                    showEditIcon: cell.showEditIcon,
-                    onTap: cell.onTap,
-                    onLongPress: cell.onLongPress,
-                    onTapDown: cell.onTapDown,
-                    onDoubleTap: cell.onDoubleTap,
-                    onTapCancel: cell.onTapCancel,
-                  ),
-                );
+                  );
+                } else {
+                  cells.add(const DataCell(SizedBox.shrink()));
+                }
               }
               bodyRows.add(
                 DataRow(

--- a/lib/ui/app/tables/entity_list.dart
+++ b/lib/ui/app/tables/entity_list.dart
@@ -241,73 +241,70 @@ class _EntityListState extends State<EntityList> {
                 },
               ),
             Expanded(
-              child: SingleChildScrollView(
-                primary: true,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  child: AppPaginatedDataTable(
-                    onSelectAll: (value) {
-                      final startIndex =
-                          min(_firstRowIndex, entityList.length - 1);
-                      final endIndex =
-                          min(_firstRowIndex + rowsPerPage, entityList.length);
-                      final entities = entityList
-                          .sublist(startIndex, endIndex)
-                          .map<BaseEntity>((String? entityId) =>
-                              entityMap![entityId] as BaseEntity)
-                          .where((invoice) =>
-                              value != listUIState.isSelected(invoice.id))
-                          .toList();
-                      handleEntitiesActions(
-                          entities, EntityAction.toggleMultiselect);
-                    },
-                    columns: [
-                      if (!isInMultiselect) DataColumn(label: SizedBox()),
-                      ...widget.tableColumns!.map((field) {
-                        String? label =
-                            AppLocalization.of(context)!.lookup(field);
-                        if (field.startsWith('custom')) {
-                          final key = field.replaceFirst(
-                              'custom', entityType.snakeCase);
-                          label = state.company.getCustomFieldLabel(key);
-                        }
-                        return DataColumn(
-                            label: Container(
-                              child: Text(
-                                label,
-                                overflow: TextOverflow.ellipsis,
-                              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: AppPaginatedDataTable(
+                  onSelectAll: (value) {
+                    final startIndex =
+                        min(_firstRowIndex, entityList.length - 1);
+                    final endIndex =
+                        min(_firstRowIndex + rowsPerPage, entityList.length);
+                    final entities = entityList
+                        .sublist(startIndex, endIndex)
+                        .map<BaseEntity>((String? entityId) =>
+                            entityMap![entityId] as BaseEntity)
+                        .where((invoice) =>
+                            value != listUIState.isSelected(invoice.id))
+                        .toList();
+                    handleEntitiesActions(
+                        entities, EntityAction.toggleMultiselect);
+                  },
+                  columns: [
+                    if (!isInMultiselect) DataColumn(label: SizedBox()),
+                    ...widget.tableColumns!.map((field) {
+                      String? label =
+                          AppLocalization.of(context)!.lookup(field);
+                      if (field.startsWith('custom')) {
+                        final key = field.replaceFirst(
+                            'custom', entityType.snakeCase);
+                        label = state.company.getCustomFieldLabel(key);
+                      }
+                      return DataColumn(
+                          label: Container(
+                            child: Text(
+                              label,
+                              overflow: TextOverflow.ellipsis,
                             ),
-                            onSort: (int columnIndex, bool ascending) {
-                              widget.onSortColumn(field);
-                            });
-                      }),
-                    ],
-                    source: dataTableSource,
-                    sortColumnIndex: widget.tableColumns!
-                            .contains(listUIState.sortField)
-                        ? widget.tableColumns!.indexOf(listUIState.sortField) +
-                            1
-                        : 0,
-                    sortAscending: listUIState.sortAscending,
-                    rowsPerPage: state.prefState.rowsPerPage,
-                    showFirstLastButtons: true,
-                    onPageChanged: (row) {
-                      _firstRowIndex = row;
-                      store.dispatch(UpdateLastHistory(
-                          (row / state.prefState.rowsPerPage).floor()));
-                    },
-                    initialFirstRowIndex: _firstRowIndex,
-                    availableRowsPerPage: [
-                      10,
-                      25,
-                      50,
-                      100,
-                    ],
-                    onRowsPerPageChanged: (value) {
-                      store.dispatch(UpdateUserPreferences(rowsPerPage: value));
-                    },
-                  ),
+                          ),
+                          onSort: (int columnIndex, bool ascending) {
+                            widget.onSortColumn(field);
+                          });
+                    }),
+                  ],
+                  source: dataTableSource,
+                  sortColumnIndex: widget.tableColumns!
+                          .contains(listUIState.sortField)
+                      ? widget.tableColumns!.indexOf(listUIState.sortField) +
+                          1
+                      : 0,
+                  sortAscending: listUIState.sortAscending,
+                  rowsPerPage: state.prefState.rowsPerPage,
+                  showFirstLastButtons: true,
+                  onPageChanged: (row) {
+                    _firstRowIndex = row;
+                    store.dispatch(UpdateLastHistory(
+                        (row / state.prefState.rowsPerPage).floor()));
+                  },
+                  initialFirstRowIndex: _firstRowIndex,
+                  availableRowsPerPage: [
+                    10,
+                    25,
+                    50,
+                    100,
+                  ],
+                  onRowsPerPageChanged: (value) {
+                    store.dispatch(UpdateUserPreferences(rowsPerPage: value));
+                  },
                 ),
               ),
             ),

--- a/lib/ui/reports/reports_screen.dart
+++ b/lib/ui/reports/reports_screen.dart
@@ -455,20 +455,77 @@ class ReportsScreen extends StatelessWidget {
                   ),
                 ),
               )
-            : ScrollableListView(
-                primary: true,
-                key: ValueKey(
-                    '${viewModel.state.company.id}_${viewModel.state.isSaving}_${reportsState.report}_${reportsState.group}'),
-                children: <Widget>[
-                  isMobile(context)
-                      ? FormCard(
-                          children: [
-                            ...reportChildren,
-                            ...dateChildren,
-                            ...chartChildren,
-                          ],
-                        )
-                      : Row(
+            : isMobile(context)
+                ? ScrollableListView(
+                    primary: true,
+                    key: ValueKey(
+                        '${viewModel.state.company.id}_${viewModel.state.isSaving}_${reportsState.report}_${reportsState.group}'),
+                    children: <Widget>[
+                      FormCard(
+                        children: [
+                          ...reportChildren,
+                          ...dateChildren,
+                          ...chartChildren,
+                        ],
+                      ),
+                      if (isMobile(context))
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Row(
+                            children: [
+                              Builder(builder: (BuildContext context) {
+                                return Expanded(
+                                  child: AppButton(
+                                    label: localization.columns,
+                                    onPressed: () {
+                                      multiselectDialog(
+                                        context: context,
+                                        onSelected: (selected) {
+                                          viewModel.onReportColumnsChanged(
+                                              context, selected);
+                                        },
+                                        options: reportResult.allColumns,
+                                        selected: reportResult.columns.toList(),
+                                        defaultSelected:
+                                            reportResult.defaultColumns,
+                                      );
+                                    },
+                                  ),
+                                );
+                              }),
+                              SizedBox(width: kGutterWidth),
+                              Expanded(
+                                child: AppButton(
+                                  label: localization.export,
+                                  onPressed: () {
+                                    viewModel.onExportPressed(context);
+                                  },
+                                ),
+                              ),
+                              SizedBox(width: kGutterWidth),
+                              Expanded(
+                                child: AppButton(
+                                  label: localization.schedule,
+                                  onPressed: () {
+                                    viewModel.onSchedulePressed(context);
+                                  },
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ReportDataTable(
+                        key: ValueKey(
+                            '${viewModel.state.isSaving}_${reportsState.group}_${reportsState.selectedGroup}'),
+                        viewModel: viewModel,
+                      )
+                    ],
+                  )
+                : Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: <Widget>[
                             Flexible(
@@ -500,59 +557,16 @@ class ReportsScreen extends StatelessWidget {
                             )
                           ],
                         ),
-                  if (isMobile(context))
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Row(
-                        children: [
-                          Builder(builder: (BuildContext context) {
-                            return Expanded(
-                              child: AppButton(
-                                label: localization.columns,
-                                onPressed: () {
-                                  multiselectDialog(
-                                    context: context,
-                                    onSelected: (selected) {
-                                      viewModel.onReportColumnsChanged(
-                                          context, selected);
-                                    },
-                                    options: reportResult.allColumns,
-                                    selected: reportResult.columns.toList(),
-                                    defaultSelected:
-                                        reportResult.defaultColumns,
-                                  );
-                                },
-                              ),
-                            );
-                          }),
-                          SizedBox(width: kGutterWidth),
-                          Expanded(
-                            child: AppButton(
-                              label: localization.export,
-                              onPressed: () {
-                                viewModel.onExportPressed(context);
-                              },
-                            ),
-                          ),
-                          SizedBox(width: kGutterWidth),
-                          Expanded(
-                            child: AppButton(
-                              label: localization.schedule,
-                              onPressed: () {
-                                viewModel.onSchedulePressed(context);
-                              },
-                            ),
-                          ),
-                        ],
                       ),
-                    ),
-                  ReportDataTable(
-                    key: ValueKey(
-                        '${viewModel.state.isSaving}_${reportsState.group}_${reportsState.selectedGroup}'),
-                    viewModel: viewModel,
-                  )
-                ],
-              ),
+                      Expanded(
+                        child: ReportDataTable(
+                          key: ValueKey(
+                              '${viewModel.state.isSaving}_${reportsState.group}_${reportsState.selectedGroup}'),
+                          viewModel: viewModel,
+                        ),
+                      ),
+                    ],
+                  ),
       ),
     );
   }
@@ -692,22 +706,41 @@ class _ReportDataTableState extends State<ReportDataTable> {
                     ],
                   ),
           ),
-        SingleChildScrollView(
-          padding: const EdgeInsets.all(12),
-          child: AppPaginatedDataTable(
-            sortColumnIndex: sortedColumns.contains(reportSettings.sortColumn)
-                ? sortedColumns.indexOf(reportSettings.sortColumn)
-                : null,
-            sortAscending: reportSettings.sortAscending,
-            columns: reportResult.tableColumns(
-                context,
-                (index, ascending) => widget.viewModel
-                    .onReportSorted(sortedColumns[index], ascending)),
-            source: dataTableSource,
-            showFirstLastButtons: true,
-            subtractOne: true,
-          ),
-        )
+        isMobile(context)
+            ? SingleChildScrollView(
+                padding: const EdgeInsets.all(12),
+                child: AppPaginatedDataTable(
+                  sortColumnIndex: sortedColumns.contains(reportSettings.sortColumn)
+                      ? sortedColumns.indexOf(reportSettings.sortColumn)
+                      : null,
+                  sortAscending: reportSettings.sortAscending,
+                  columns: reportResult.tableColumns(
+                      context,
+                      (index, ascending) => widget.viewModel
+                          .onReportSorted(sortedColumns[index], ascending)),
+                  source: dataTableSource,
+                  showFirstLastButtons: true,
+                  subtractOne: true,
+                ),
+              )
+            : Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: AppPaginatedDataTable(
+                    sortColumnIndex: sortedColumns.contains(reportSettings.sortColumn)
+                        ? sortedColumns.indexOf(reportSettings.sortColumn)
+                        : null,
+                    sortAscending: reportSettings.sortAscending,
+                    columns: reportResult.tableColumns(
+                        context,
+                        (index, ascending) => widget.viewModel
+                            .onReportSorted(sortedColumns[index], ascending)),
+                    source: dataTableSource,
+                    showFirstLastButtons: true,
+                    subtractOne: true,
+                  ),
+                ),
+              )
       ],
     );
   }

--- a/lib/ui/reports/reports_screen.dart
+++ b/lib/ui/reports/reports_screen.dart
@@ -468,10 +468,9 @@ class ReportsScreen extends StatelessWidget {
                           ...chartChildren,
                         ],
                       ),
-                      if (isMobile(context))
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          child: Row(
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: Row(
                             children: [
                               Builder(builder: (BuildContext context) {
                                 return Expanded(
@@ -523,39 +522,43 @@ class ReportsScreen extends StatelessWidget {
                   )
                 : Column(
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 12),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            Flexible(
-                              child: FormCard(
-                                children: reportChildren,
-                                padding: const EdgeInsets.only(
-                                    top: kMobileDialogPadding,
-                                    right: kMobileDialogPadding / 2,
-                                    left: kMobileDialogPadding),
-                              ),
+                      Flexible(
+                        child: SingleChildScrollView(
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 12),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                Flexible(
+                                  child: FormCard(
+                                    children: reportChildren,
+                                    padding: const EdgeInsets.only(
+                                        top: kMobileDialogPadding,
+                                        right: kMobileDialogPadding / 2,
+                                        left: kMobileDialogPadding),
+                                  ),
+                                ),
+                                Flexible(
+                                  child: FormCard(
+                                    children: dateChildren,
+                                    padding: const EdgeInsets.only(
+                                        top: kMobileDialogPadding,
+                                        right: kMobileDialogPadding / 2,
+                                        left: kMobileDialogPadding / 2),
+                                  ),
+                                ),
+                                Flexible(
+                                  child: FormCard(
+                                    children: chartChildren,
+                                    padding: const EdgeInsets.only(
+                                        top: kMobileDialogPadding,
+                                        right: kMobileDialogPadding,
+                                        left: kMobileDialogPadding / 2),
+                                  ),
+                                )
+                              ],
                             ),
-                            Flexible(
-                              child: FormCard(
-                                children: dateChildren,
-                                padding: const EdgeInsets.only(
-                                    top: kMobileDialogPadding,
-                                    right: kMobileDialogPadding / 2,
-                                    left: kMobileDialogPadding / 2),
-                              ),
-                            ),
-                            Flexible(
-                              child: FormCard(
-                                children: chartChildren,
-                                padding: const EdgeInsets.only(
-                                    top: kMobileDialogPadding,
-                                    right: kMobileDialogPadding,
-                                    left: kMobileDialogPadding / 2),
-                              ),
-                            )
-                          ],
+                          ),
                         ),
                       ),
                       Expanded(


### PR DESCRIPTION
### Description

This update addresses review feedback on the sticky header table scrolling implementation by resolving column misalignments, optimizing performance, implementing robust text measurements, and restoring original comments in `AppPaginatedDataTable`.

Key Changes

1. **Sticky Header Checkbox & Column Alignment Fix**
   - Fixed the 56px shift misalignment between the sticky header and the table body. 
   - When selectable rows are present, the header `DataTable` is supplied with a dummy selectable row to force the checkbox column to build.
   - Wrapped the header table in a `ClipRect` with a height constrained to `widget.headingRowHeight` so that the dummy row itself is clipped out and never rendered, achieving perfect alignment between header and body columns.

2. **Robust Localization Support via `TextPainter`**
   - Removed the English-only text-width guessing heuristic (`_guessWidthFromText`).
   - Implemented a recursive widget-traversing helper `_findTextWidget` supporting common layout and gesture containers (`Padding`, `Container`, `Tooltip`, `SizedBox`, etc.).
   - Added `_measureWidgetText` which uses `TextPainter` with active locale directionality and typography settings (`headingTextStyle` and `dataTextStyle`) to calculate exact localized text widths.

3. **Performance Optimization (Caching & Deduplication)**
   - Added width caching fields to state (`_cachedColumnWidths`, `_cachedFirstRowIndex`, etc.) to prevent redundant column width calculations on every frame.
   - Recalculations are bypassed unless the data source, columns length, or page index changes.
   - Deduplicated row generation by calling `_getRows(...)` exactly once in `build()`, passing the result down to the width measurement wrapper (which samples via `.take(5)`).
   - Removed redundant sort indicator calculations (`sortColumnIndex: null`) on the hidden body table header.

4. **Comments Restored**
   - Restored original Flutter Framework comments (RTL support warnings, footer spacing bounds, etc.).

Verification
- Verified cleanly using `flutter analyze` with zero compilation errors or warnings.
