### PR TITLE
Fixes for design block serializer

### DIFF
--- a/lib/data/models/design_model.dart
+++ b/lib/data/models/design_model.dart
@@ -241,5 +241,60 @@ abstract class DesignEntity extends Object
     ..isTemplate = false
     ..entities = '';
 
-  static Serializer<DesignEntity> get serializer => _$designEntitySerializer;
+  static Serializer<DesignEntity> get serializer => const DesignEntitySerializer();
+}
+
+class DesignEntitySerializer implements StructuredSerializer<DesignEntity> {
+  const DesignEntitySerializer();
+
+  @override
+  final Iterable<Type> types = const [DesignEntity, _$DesignEntity];
+
+  @override
+  final String wireName = 'DesignEntity';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, DesignEntity object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return (_$designEntitySerializer as StructuredSerializer<DesignEntity>)
+        .serialize(serializers, object, specifiedType: specifiedType);
+  }
+
+  @override
+  DesignEntity deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return (_$designEntitySerializer as StructuredSerializer<DesignEntity>)
+        .deserialize(serializers, _sanitizeDesign(serialized),
+            specifiedType: specifiedType);
+  }
+
+  // Newer invoice designs carry a `blocks` array (visual builder). The
+  // generated deserializer expects every `design` value to be a String and
+  // throws on it, so we drop the non-string entries before delegating.
+
+  static Iterable<Object?> _sanitizeDesign(Iterable<Object?> serialized) {
+    final result = <Object?>[];
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current;
+      if (!iterator.moveNext()) {
+        result.add(key);
+        break;
+      }
+      var value = iterator.current;
+      if (key == 'design' && value is Map) {
+        value = <String, String>{
+          for (final entry in value.entries)
+            if (entry.key is String && entry.value is String)
+              entry.key as String: entry.value as String
+        };
+      }
+      result
+        ..add(key)
+        ..add(value);
+    }
+    return result;
+  }
 }

--- a/test/design_model_test.dart
+++ b/test/design_model_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:invoiceninja_flutter/constants.dart';
+import 'package:invoiceninja_flutter/data/models/design_model.dart';
+import 'package:invoiceninja_flutter/data/models/serializers.dart';
+
+void main() {
+  group('DesignEntity deserialization', () {
+    test('drops non-string design values (blocks array) instead of crashing',
+        () {
+      final raw = <Object?, Object?>{
+        'id': 'x1',
+        'name': 'Visual Design',
+        'is_custom': true,
+        'is_free': false,
+        'is_template': false,
+        'entities': 'invoice,quote',
+        'created_at': 0,
+        'updated_at': 0,
+        'archived_at': 0,
+        'design': <String, Object?>{
+          'blocks': [
+            {'type': 'text', 'properties': {'content': '\$company.name'}},
+          ],
+          'header': '<div>header</div>',
+          'body': '<div>body</div>',
+          'footer': '<div>footer</div>',
+          'product': '',
+          'task': '',
+          'includes': '<style></style>',
+        },
+      };
+
+      final entity = serializers.deserializeWith(DesignEntity.serializer, raw);
+
+      expect(entity, isNotNull);
+      expect(entity!.name, 'Visual Design');
+      expect(entity.design[kDesignHeader], '<div>header</div>');
+      expect(entity.design[kDesignBody], '<div>body</div>');
+      expect(entity.design.containsKey('blocks'), isFalse);
+    });
+
+    test('design values that are strings still deserialize unchanged', () {
+      final raw = <Object?, Object?>{
+        'id': 'x2',
+        'name': 'Plain',
+        'is_custom': true,
+        'is_free': true,
+        'is_template': false,
+        'entities': '',
+        'created_at': 0,
+        'updated_at': 0,
+        'archived_at': 0,
+        'design': <String, Object?>{
+          'header': 'h',
+          'body': 'b',
+          'footer': 'f',
+        },
+      };
+
+      final entity = serializers.deserializeWith(DesignEntity.serializer, raw);
+
+      expect(entity, isNotNull);
+      expect(entity!.design[kDesignHeader], 'h');
+      expect(entity.design[kDesignBody], 'b');
+      expect(entity.design[kDesignFooter], 'f');
+    });
+  });
+}


### PR DESCRIPTION
Newer invoice designs carry a `blocks` array (visual builder). The generated deserializer expects every `design` value to be a String and throws on it, so we drop the non-string entries before delegating.

This fixes this behaviour by ignoring them on deserialization. 